### PR TITLE
Removed unused enddata variable that was causing compiler warnings

### DIFF
--- a/rsmb/src/MQTTSPacket.c
+++ b/rsmb/src/MQTTSPacket.c
@@ -401,7 +401,6 @@ void* MQTTSPacket_publish(MQTTSHeader header, char* data)
 {
 	MQTTS_Publish* pack = NULL;
 	char* curdata = data;
-	char* enddata = &data[header.len - 2];
 	int topicLen = 0;
 	int datalen = 0;
 


### PR DESCRIPTION
Signed-off-by: Nicholas Humfrey njh@aelius.com
