### PR TITLE
Added defines for IPV6_ADD_MEMBERSHIP and IPV6_DROP_MEMBERSHIP

### DIFF
--- a/rsmb/src/Socket.h
+++ b/rsmb/src/Socket.h
@@ -74,6 +74,14 @@
 #define min(A,B) ( (A) < (B) ? (A):(B))
 #endif
 
+#if !defined(IPV6_ADD_MEMBERSHIP) && defined(IPV6_JOIN_GROUP)
+#define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
+#endif
+
+#if !defined(IPV6_DROP_MEMBERSHIP) && defined(IPV6_LEAVE_GROUP)
+#define IPV6_DROP_MEMBERSHIP IPV6_LEAVE_GROUP
+#endif
+
 #include "LinkedList.h"
 #include "Tree.h"
 


### PR DESCRIPTION
These constants don't exist on BSD systems / Mac OS X.

It is not clear to me why Linux uses one set of constants and BSD uses the other:
http://stackoverflow.com/questions/10931202/what-is-the-difference-between-ipv6-add-membership-and-ipv6-join-group/13628854#13628854

Or which is preferred. But this fixes it.

Signed-off-by: Nicholas Humfrey njh@aelius.com
