### PR TITLE
Don't assume default compiler is GCC on non-Windows

### DIFF
--- a/rsmb/src/Makefile
+++ b/rsmb/src/Makefile
@@ -22,23 +22,23 @@ rsmb.ini: *.h
 
 else
 
-ifndef GCC
-  GCC = gcc
+ifndef CC
+  CC = gcc
 endif
 
 all: broker broker_dbg broker_mqtts rsmb.ini
 
 broker: *.c *.h 
-	${GCC} -Wall -s -Os *.c -o broker
+	$(CC) -Wall -Os *.c -o broker
 
 broker_dbg: *.c *.h
-	${GCC} -Wall -ggdb *.c -o broker_dbg
+	$(CC) -Wall -ggdb *.c -o broker_dbg
 
 broker_mqtts: *.c *.h
-	${GCC} -DMQTTS -Wall -s -Os *.c -o broker_mqtts
+	$(CC) -DMQTTS -Wall -Os *.c -o broker_mqtts
 	
 broker_mqtts32: *.c *.h
-	${GCC} -m32 -DMQTTS -Wall -s -Os *.c -o broker_mqtts32
+	$(CC) -m32 -DMQTTS -Wall -Os *.c -o broker_mqtts32
 
 rsmb.ini: *.h
 	perl tools/be/be.pl


### PR DESCRIPTION
This change means that make uses the compiler defined by the CC variable by default, if undefined it will still use gcc.

Mac OS X uses clang by default, not GCC.
