### PR TITLE
Removed #include for ucontext.h

### DIFF
--- a/amqtdd/src/Broker.c
+++ b/amqtdd/src/Broker.c
@@ -47,7 +47,6 @@
 #include <signal.h>
 #include <stdlib.h>
 #if !defined(WIN32)
-#include <ucontext.h>
 #define GETTIMEOFDAY 1
 #endif
 

--- a/rsmb/src/Broker.c
+++ b/rsmb/src/Broker.c
@@ -47,7 +47,6 @@
 #include <signal.h>
 #include <stdlib.h>
 #if !defined(WIN32)
-#include <ucontext.h>
 #define GETTIMEOFDAY 1
 #endif
 


### PR DESCRIPTION
It causes compile errors on Mac OS X because the ucontext functions were removed from POSIX.
Having checked through the Broker.c source code, I can't find any references to things defined in context.h:
- `ucontext_t`
- `int getcontext(ucontext_t *);`
- `int setcontext(const ucontext_t *);`
- `void makecontext(ucontext_t *, void (*)(void), int, ...);`
- `int swapcontext(ucontext_t *, const ucontext_t *);`

Signed-off-by: Nicholas Humfrey njh@aelius.com
