### PR TITLE
sending topic-id in puback message as per v1.2 spec

### DIFF
--- a/rsmb/src/MQTTSPacket.c
+++ b/rsmb/src/MQTTSPacket.c
@@ -967,7 +967,7 @@ int MQTTSPacket_send_publish(Clients* client, MQTTS_Publish* pub)
 }
 
 
-int MQTTSPacket_send_puback(Clients* client, /*char* shortTopic, int topicId, */ int msgId, char returnCode)
+int MQTTSPacket_send_puback(Clients* client, int topicId, int msgId, char returnCode)
 {
 	MQTTS_PubAck packet;
 	char *buf, *ptr;
@@ -985,7 +985,7 @@ int MQTTSPacket_send_puback(Clients* client, /*char* shortTopic, int topicId, */
 		writeChar(&ptr, shortTopic[1]);
 	}
 	else */
-		writeInt(&ptr, 0); /* writeInt(&ptr, topicId); */
+		writeInt(&ptr, topicId); /* writeInt(&ptr, 0);  */
 	writeInt(&ptr, msgId);
 	writeChar(&ptr, returnCode);
 

--- a/rsmb/src/MQTTSPacket.h
+++ b/rsmb/src/MQTTSPacket.h
@@ -288,7 +288,7 @@ int MQTTSPacket_send_pingResp(Clients* client);
 int MQTTSPacket_send_willTopicResp(Clients* client);
 int MQTTSPacket_send_willMsgResp(Clients* client);
 int MQTTSPacket_send_regAck(Clients* client, int msgId, int topicId, char rc);
-int MQTTSPacket_send_puback(Clients* client, int msgId, char returnCode);
+int MQTTSPacket_send_puback(Clients* client, int topicId, int msgId, char returnCode);
 int MQTTSPacket_send_pubrec(Clients* client, int msgId);
 int MQTTSPacket_send_pubrel(Clients* client, int msgId);
 int MQTTSPacket_send_pubcomp(Clients* client, int msgId);


### PR DESCRIPTION
Not sure if i'm missing something, but saw that the puback message always sends 00 00 in the topicId field and this seemed like a quick working fix.

Spec v1.2 of mqtt-sn (which i believe is the last published one if i'm not mistaken, since i've only found drafts for newer versions so far) says that TopicId should have the same value as the one contained in the corresponding PUBLISH message, which with this fix it now is.